### PR TITLE
feat(cli): cli exclude 

### DIFF
--- a/packages/wxa-cli/src/helpers/dependencyResolver.js
+++ b/packages/wxa-cli/src/helpers/dependencyResolver.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import PathParser from '../helpers/pathParser';
+import PathParser, { isIgnoreFile } from '../helpers/pathParser';
 import {getDistPath, isFile, readFile, isDir} from '../utils';
 import findRoot from 'find-root';
 import resolveAlias from '../helpers/alias';
@@ -82,7 +82,7 @@ class DependencyResolver {
         // resolve alias;
         if (this.resolve.alias && !mdl.isNodeModule) lib = resolveAlias(lib, this.resolve.alias, mdl.meta.source);
 
-        let pret = new PathParser().parse(lib);
+        let pret = new PathParser(this.resolve).parse(lib);
 
         debug('%s path pret %o', lib, pret);
 
@@ -109,7 +109,7 @@ class DependencyResolver {
     getOutputPath(source, pret, mdl) {
         if (pret.isRelative || pret.isAPPAbsolute || pret.isNodeModule || pret.isWXALib) {
             return this.getDistPath(source, mdl);
-        } else if (pret.isPlugin || pret.isURI) {
+        } else if (isIgnoreFile(pret)) {
             // url module
             return null;
         } else {

--- a/packages/wxa-cli/src/helpers/pathParser.js
+++ b/packages/wxa-cli/src/helpers/pathParser.js
@@ -47,8 +47,6 @@ export default class PathParser {
             ret.isDynamic = true;
         } else if (x[0] === '.') { // require('./') require('../')
             ret.isRelative = true;
-        } else if (x[0] === '#') { // require('#') require plugin plugin require('plugin name')
-            ret.isPlugin = true;
         } else if (this.pkgReg.test(x)) { // require('@scope/pkg') require('pkg')
             ret.isNodeModule = true;
         } else if (x[0] === '/') { // require('/abcd')

--- a/packages/wxa-cli/src/helpers/pathParser.js
+++ b/packages/wxa-cli/src/helpers/pathParser.js
@@ -3,19 +3,34 @@ import logger from './logger';
 import validUrl from 'valid-url';
 
 export default class PathParser {
-    constructor() {
+    constructor(resolveConfigs = {}) {
         this.pkgReg = /^[@\w\_\-\d\.]+(\/[\w\-\_\d@\.]+)*$/;
         this.base64Reg = /^data:[\w\/;,+]/;
         this.dynamicReg = /{{[^{}]*}}/;
+
+        if (resolveConfigs.exclude) {
+            let exclude = Array.isArray(resolveConfigs.exclude) ? resolveConfigs.exclude : [resolveConfigs.exclude];
+
+            let excludeRegArr = exclude.map((item) => {
+                return typeof item === 'string' ? new RegExp(item, 'g') : item
+            });
+
+            this.isExcludeFile = (pathString) => {
+                return excludeRegArr.some((reg) => reg.test(pathString))
+            }
+        } else {
+            this.isExcludeFile = () => false;
+        }
     }
 
     parse(x) {
         if (typeof x !== 'string') throw new Error('path must be a string');
 
         let ret = {
+            isExcludeFile: false,
             isRelative: false,
             isNodeModule: false,
-            isAbsolute: false,
+            isAPPAbsolute: false,
             isURI: false,
             isPlugin: false,
             isWXALib: false,
@@ -25,7 +40,9 @@ export default class PathParser {
 
         // judge path's kind;
         // dynamic string is highest priority.
-        if (this.dynamicReg.test(x)) {
+        if (this.isExcludeFile(x)) {
+            ret.isExcludeFile = true;
+        } if (this.dynamicReg.test(x)) {
             ret.isURI = true;
             ret.isDynamic = true;
         } else if (x[0] === '.') { // require('./') require('../')
@@ -36,17 +53,23 @@ export default class PathParser {
             ret.isNodeModule = true;
         } else if (x[0] === '/') { // require('/abcd')
             ret.isAPPAbsolute = true;
+        } else if (this.base64Reg.test(x)) {
+            ret.isURI = true;
+            ret.isBase64 = true;
         } else if (validUrl.is_uri(x)) { // components from plugin or uri
             if (x.indexOf('plugin://') === 0) ret.isPlugin = true;
             else if (x.indexOf('wxa://') === 0) (ret.isWXALib = true, ret.name = x.slice(6));
             else ret.isURI = true;
-        } else if (this.base64Reg.test(x)) {
-            ret.isURI = true;
-            ret.isBase64 = true;
         } else {
             throw new Error('Path Error', '无法解析的路径类型: '+x);
         }
 
         return ret;
     }
+}
+
+export function isIgnoreFile(mdl) {
+    let ignoreFileType = ['isExcludeFile', 'isURI', 'isPlugin', 'isBase64', 'isDynamic'];
+
+    return ignoreFileType.some((item) => mdl[item]);
 }

--- a/packages/wxa-cli/src/resolvers/component/index.js
+++ b/packages/wxa-cli/src/resolvers/component/index.js
@@ -1,5 +1,5 @@
 import DependencyResolver from '../../helpers/dependencyResolver';
-import PathParser from '../../helpers/pathParser';
+import PathParser, { isIgnoreFile } from '../../helpers/pathParser';
 import logger from '../../helpers/logger';
 import {isFile} from '../../utils';
 import debugPKG from 'debug';
@@ -55,7 +55,7 @@ export default class ComponentManager {
                 let outputPath = dr.getOutputPath(source, pret, mdl);
                 let resolved = dr.getResolved(lib, outputPath, mdl);
 
-                if (pret.isPlugin || pret.isURI) return ret;
+                if (isIgnoreFile(pret)) return ret;
 
                 // check if wxa file.
                 if (isFile(source+this.meta.wxaExt)) {

--- a/packages/wxa-cli/src/schedule.js
+++ b/packages/wxa-cli/src/schedule.js
@@ -17,6 +17,7 @@ import DependencyResolver from './helpers/dependencyResolver';
 import ProgressTextBar from './helpers/progressTextBar';
 import Preformance from './helpers/performance';
 import simplify from './helpers/simplifyObj';
+import {isIgnoreFile} from './helpers/pathParser';
 
 let debug = debugPKG('WXA:Schedule');
 
@@ -279,10 +280,7 @@ class Schedule {
         // if a dependency is from remote, or dynamic path, or base64 format, then we ignore it.
         // cause we needn't process this kind of resource.
         if (
-            dep.pret.isURI ||
-            dep.pret.isDynamic ||
-            dep.pret.isBase64 ||
-            dep.pret.isPlugin
+            isIgnoreFile(dep.pret)
         ) return null;
 
         debug('Find Dependencies started %O', simplify(dep));

--- a/packages/wxa-cli/test/helpers/path.parser.test.js
+++ b/packages/wxa-cli/test/helpers/path.parser.test.js
@@ -1,0 +1,84 @@
+
+
+import PathParser, {isIgnoreFile} from '../../src/helpers/pathParser';
+
+describe('PathParser: wxa path recognizer', ()=>{
+    test('detect target type', () => {
+        let parser = new PathParser();
+
+        expect(parser.parse('./foo.js')).toMatchObject({
+            isRelative: true
+        });
+        
+        expect(parser.parse('/foo.js')).toMatchObject({
+            isAPPAbsolute: true
+        });
+
+        expect(parser.parse('plugin://plugin-page/foo')).toMatchObject({
+            isWXALib: false,
+            isPlugin: true
+        });
+
+        expect(parser.parse('#mp-plugin')).toMatchObject({
+            isWXALib: false,
+            isPlugin: true
+        });
+
+        expect(parser.parse('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAqgAAAAjCAMAAABvjghcAAAASFBMVEVPl')).toMatchObject({
+            isPlugin: false,
+            isBase64: true
+        });
+
+        expect(parser.parse('@wxa/core')).toMatchObject({
+            isNodeModule: true
+        });
+        expect(parser.parse('lodash/xxx')).toMatchObject({
+            isNodeModule: true
+        });
+
+        expect(parser.parse('https://google.com')).toMatchObject({
+            isURI: true
+        });
+
+        expect(parser.parse('wxa://google.com')).toMatchObject({
+            isWXALib: true
+        });
+
+        expect(parser.parse('https://{{HOST}}/ajdifj')).toMatchObject({
+            isDynamic: true,
+            isURI: true
+        });
+    });
+
+    test('exclude file', () => {
+        let parser = new PathParser({exclude: '/miniprogram_npm'});
+
+        expect(parser.parse('/miniprogram_npm/weui-miniprogram/dialog/dialog')).toMatchObject({
+            isExcludeFile: true
+        });
+
+        let parser2 = new PathParser({exclude: ['/miniprogram_npm', /wxa\-ui/]});
+
+        expect(parser2.parse('/miniprogram_npm/weui-miniprogram/dialog/dialog')).toMatchObject({
+            isExcludeFile: true
+        });
+
+        expect(parser2.parse('/miniprogram_npm/wxa-ui/dialog/dialog')).toMatchObject({
+            isExcludeFile: true
+        });
+    })
+
+    test('thow error while cannot recognize path type', () => {
+        let parser = new PathParser({});
+
+        expect(()=>parser.parse('🚀')).toThrowError();
+
+        expect(()=>parser.parse({path: '🚀'})).toThrowError();
+    })
+});
+
+test('isIgnoreFile', () => {
+    expect(isIgnoreFile({
+        isExcludeFile: true
+    })).toBe(true);
+});

--- a/packages/wxa-cli/test/helpers/path.parser.test.js
+++ b/packages/wxa-cli/test/helpers/path.parser.test.js
@@ -19,10 +19,10 @@ describe('PathParser: wxa path recognizer', ()=>{
             isPlugin: true
         });
 
-        expect(parser.parse('#mp-plugin')).toMatchObject({
-            isWXALib: false,
-            isPlugin: true
-        });
+        // expect(parser.parse('#mp-plugin')).toMatchObject({
+        //     isWXALib: false,
+        //     isPlugin: true
+        // });
 
         expect(parser.parse('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAqgAAAAjCAMAAABvjghcAAAASFBMVEVPl')).toMatchObject({
             isPlugin: false,


### PR DESCRIPTION
#74 

核心功能点：@wxa/cli 解析支持exclude

目前会有几个场景依赖该功能：

- 作为UI工具库编译的时候，使用的 peer 依赖需要排除在打包的结果之内
- 使用小程序开发者工具内置库的时候（useExtendsLib)
- 使用replace插件动态写入参数的时候
- 这几种场景都应该停止依赖解析。

Expected Results
小程序场景中 externals 约等于 exclude

