### PR TITLE
feat(cli): Add package resolve support

### DIFF
--- a/packages/wxa-cli/src/helpers/alias.js
+++ b/packages/wxa-cli/src/helpers/alias.js
@@ -1,9 +1,12 @@
 import path from 'path';
+import PathParser from './pathParser';
 
 export default function resolveAlias(lib, alias, filepath) {
     if (alias == null) return lib;
 
     let opath = path.parse(filepath);
+
+    let pathParser = new PathParser();
 
     Object.keys(alias).forEach((key)=>{
         let value = alias[key];
@@ -13,9 +16,13 @@ export default function resolveAlias(lib, alias, filepath) {
             let tar = lib.replace(new RegExp(key, 'g'), value);
             // logger.info('parsed lib', tar);
             // calc relative path base cwd;
-            tar = path.relative(opath.dir, tar);
-            lib = './'+tar
-                    .replace(/\\/g, '/');
+            let {isRelative} = pathParser.parse(tar);
+            if (isRelative) {
+                tar = path.relative(opath.dir, tar);
+                lib = './'+tar.replace(/\\/g, '/');
+            } else {
+                lib = tar;
+            }
         }
     });
 


### PR DESCRIPTION
Add package resolve support and make alias available with npm package.

re #90 #89

为了做到无缝支持引用符合开发者工具的npm包，我们需要新增以下能力：

- [x] 递归寻找并检查 package.json
- [x] 依次检查 package.json 的 miniprogram, browser, main 配置
- [x] alias 支持 npm 包

**用法**

以 `@vant/weapp` 为例，在完全不需要额外的配置下，可以直接在页面中使用 `index.wxa` 
``` vue
<config>
{
    "navigationBarTitleText": "首页",
    "usingComponents": {
      "van-button": "@vant/weapp/button/index"
    }
}
</config>
```

搭配 `alias` 使用：
`wxa.config.js` 新增配置如下： 
```js
module.exports = {
    resolve: {
        alias: {
            '@vant': '@vant/weapp',
        }
    }
};
```

则页面中可以直接使用如下写法：

``` vue
<config>
{
    "navigationBarTitleText": "首页",
    "usingComponents": {
      "van-button": "@vant/button/index"
    }
}
</config>
```

这种用法在大量使用第三方的组件库的时候非常好用。










