### PR TITLE
feat: add command to convert native syntax to WXA files

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.2.10"
+  "version": "2.2.11"
 }

--- a/packages/wxa-cli/.eslintrc.json
+++ b/packages/wxa-cli/.eslintrc.json
@@ -27,7 +27,8 @@
         "no-trailing-spaces": "off",
         "require-jsdoc": "off",
         "camelcase": "warn",
-        "no-invalid-this": "warn"
+        "no-invalid-this": "warn",
+        "linebreak-style": [0 ,"error", "windows"]
     },
     "plugins": []
 }

--- a/packages/wxa-cli/README.md
+++ b/packages/wxa-cli/README.md
@@ -55,3 +55,6 @@ npm i -g @wxa/cli2@next
     - `wxa2 cli -a preview`: 预览项目
     - `wxa2 cli -a upload`: 上传项目
     - `wxa2 cli -a login`: 登录微信，`preview`和`upload`都需要登录微信后操作
+
+6. 原生代码转换为 `.wxa` 代码  
+`wxa convert -i <src directory> -o <output directory>`

--- a/packages/wxa-cli/src/convert.js
+++ b/packages/wxa-cli/src/convert.js
@@ -1,0 +1,117 @@
+import {getFiles, readFile, writeFile} from './utils';
+const path = require('path');
+
+function parse(dir) {
+    let paths = getFiles(dir);
+    let files = paths.map((p) => {
+        let absolutePath = path.join(dir, p);
+        let content = readFile(absolutePath);
+
+        return {
+            content,
+            path: p,
+        };
+    });
+    let groupedFiles = {
+        other: [],
+    };
+
+    files.forEach((file) => {
+        let extname = path.extname(file.path);
+
+        if (['.wxss', '.wxml', '.js', '.json'].includes(extname)) {
+            let name = file.path.replace(extname, '');
+            groupedFiles[name] = groupedFiles[name] || [];
+            groupedFiles[name].push(file);
+
+            return;
+        }
+
+        groupedFiles.other.push(file);
+    });
+
+    for (const [name, files] of Object.entries(groupedFiles)) {
+        if (name !== 'other') {
+            let keep = files.some((file) => {
+                let extname = path.extname(file.path);
+                return ['.wxss', '.wxml'].includes(extname);
+            });
+
+            if (!keep) {
+                groupedFiles.other = groupedFiles.other.concat(files);
+                delete groupedFiles[name];
+            }
+        }
+    }
+
+    return groupedFiles;
+}
+
+function formatContent(content, type) {
+    if (typeof content !== 'string') {
+        throw new Error(`${content} is not String`);
+    }
+
+    let res = [];
+
+    for (let i = 0; i < content.length; i++) {
+        if (i === content.length - 1 && content[i] === '\n') {
+            res[i] = '';
+        } else if (type === 'wxml') {
+            if (i === 0) {
+                res[i] = '  ' + content[i];  
+            } else if (content[i] === '\n') {
+                res[i] = content[i] + '  ';
+            } else {
+                res[i] = content[i];
+            }
+        } else {
+            res[i] = content[i];
+        }
+    }
+
+    return res.join('');
+}
+
+function output(groupedFiles, outputDir) {
+    for (const [name, files] of Object.entries(groupedFiles)) {
+        if (name !== 'other') {
+            let res = [];
+            files.forEach((file) => {
+                let type = path.extname(file.path).replace('.', '');
+                let content = formatContent(file.content, type);
+                switch (type) {
+                    case 'js':
+                        res[0] = `<script>\n${content}\n</script>\n\n`;
+                        break;
+                    case 'json':
+                        res[1] = `<config>\n${content}\n</config>\n\n`;
+                        break;
+                    case 'wxml':
+                        res[2] = `<template>\n${content}\n</template>\n\n`;
+                        break;
+                    case 'wxss':
+                        res[3] = `<style>\n${content}\n</style>\n\n`;
+                        break;
+                    default:
+                        break;
+                }
+            });
+
+            res = res.join('');
+            let p = path.join(outputDir, name + '.wxa');
+            writeFile(p, res);
+        } else {
+            files.forEach((file) => {
+                let p = path.join(outputDir, file.path);
+                writeFile(p, file.content);
+            });
+        }
+    }
+}
+
+export default function convert(cmd) {
+    let {input: inputDir, output: outDir} = cmd;
+    let groupedFiles = parse(inputDir);
+    output(groupedFiles, outDir);
+}

--- a/packages/wxa-cli/src/wxa.js
+++ b/packages/wxa-cli/src/wxa.js
@@ -3,6 +3,7 @@ import https from 'https';
 import {spawnBuilder} from './builder';
 import chalk from 'chalk';
 import Creator from './creator';
+import convert from './convert';
 import {spawnDevToolCli} from './toolcli';
 import {getConfigs} from './getConfigs';
 import {WXA_PROJECT_NAME} from './const/wxaConfigs';
@@ -80,6 +81,18 @@ commander
         processProjectsOptions(configs, cmd);
 
         spawnDevToolCli(configs, cmd);
+    });
+
+commander
+    .command('convert')
+    .description('原生小程序代码转 wxa')
+    .option('-i, --input <input>', '原生小程序代码路径')
+    .option('-o, --output <output>', '输出路径')
+    .action(async (cmd)=>{
+        showSlogan();
+        console.info('🦊 Converting 转换中');
+
+        convert(cmd);
     });
 
 commander.parse(process.argv);

--- a/packages/wxa-core/package-lock.json
+++ b/packages/wxa-core/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@wxa/core",
-    "version": "2.2.7",
+    "version": "2.2.11",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/packages/wxa-core/package.json
+++ b/packages/wxa-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wxa/core",
-    "version": "2.2.7",
+    "version": "2.2.11",
     "description": "wxa core feature",
     "main": "./dist/main.js",
     "scripts": {

--- a/packages/wxa-redux/package-lock.json
+++ b/packages/wxa-redux/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wxa/redux",
-	"version": "2.2.9",
+	"version": "2.2.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/wxa-redux/package.json
+++ b/packages/wxa-redux/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wxa/redux",
-    "version": "2.2.9",
+    "version": "2.2.11",
     "description": "redux for wxa ",
     "main": "./dist/index.js",
     "scripts": {

--- a/packages/wxa-redux/src/index.js
+++ b/packages/wxa-redux/src/index.js
@@ -197,13 +197,13 @@ export const wxaRedux = (options = {}) => {
                 vm.pageLifetimes = pageLifetimes || {};
                 let {show, hide} = vm.pageLifetimes;
                 // auto sync store data to component.
-                vm.pageLifetimes.show = function(args) {
-                    syncStore.bind(this)();
-                    if (show) show.apply(this, args);
+                vm.pageLifetimes.show = function(...args) {
+                    if (this.$$reduxDiff) syncStore.bind(this)();
+                    if (show) show.apply(this, ...args);
                 }
-                vm.pageLifetimes.hide = function(args) {
+                vm.pageLifetimes.hide = function(...args) {
                     this.$$isCurrentPage = false;
-                    if (hide) hide.apply(this, args);
+                    if (hide) hide.apply(this, ...args);
                 }
 
                 vm.created = function (...args) {

--- a/packages/wxa-watch/package-lock.json
+++ b/packages/wxa-watch/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wxa/watch",
-	"version": "2.2.10",
+	"version": "2.2.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/wxa-watch/package.json
+++ b/packages/wxa-watch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxa/watch",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "watch plugin for wxa",
   "main": "dist/index.js",
   "scripts": {
@@ -17,7 +17,7 @@
   "repository": "https://github.com/wxajs/wxa.git",
   "homepage": "https://wxajs.github.io/wxa/",
   "dependencies": {
-    "@wxa/core": "^2.2.7",
+    "@wxa/core": "^2.2.11",
     "melanke-watchjs": "^1.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
#88 
命令：wxa convert -i <input dir> -o <output dir>
将 `<input dir>` 目录下的原生小程序代码反向编译到 `<output dir>` 目录。
现在只会将 `.wxss`, `.json`, `.js`, `.wxml` 合并到一个 `.wxa` 文件中，而不会进行语法的转换。

