### PR TITLE
feat(cli): Allow use import declaration to add static file to project

### DIFF
--- a/packages/wxa-cli/src/resolvers/ast/index.js
+++ b/packages/wxa-cli/src/resolvers/ast/index.js
@@ -9,6 +9,12 @@ import {generateCodeFromAST} from '../../compilers/script';
 
 let debug = debugPKG('WXA:ASTManager');
 
+const isStaticSource = (filepath) => {
+    let ext = path.extname(filepath);
+
+    return ~['png','jpg','jpeg','webp','eot','woff','woff2','ttf','file', 'gif','webm', 'mp3', 'mp4'].indexOf(ext.replace(/^\./, ''));
+}
+
 export default class ASTManager {
     constructor(resolve, meta, wxaConfigs) {
         this.resolve = resolve;
@@ -136,6 +142,12 @@ export default class ASTManager {
                             source, outputPath, resolved,
                         },
                     });
+                    
+                    // Allow use import to add static file to project
+                    if (isStaticSource(source)) {
+                        path.remove();
+                        return;
+                    }
 
                     switch (typeOfPath) {
                         case StringLiteralRequire:


### PR DESCRIPTION
Now we support using import declaration to attach the static source to the mini-program project tree.

```js
import {App} from '@wxa/core';

import "./change-arrow.png";

@App
export default class Main {
    globalData = {
        userInfo: 'Genuifx',
    }
}
```

The CLI will auto-delete `import "./change-arrow.png";`  and add the static source to compiled dest.

re #123